### PR TITLE
SDLApp, SerialConifg: Decouple SerialProto from SerialConfig

### DIFF
--- a/include/gui/SerialConfig.hpp
+++ b/include/gui/SerialConfig.hpp
@@ -1,18 +1,19 @@
 #ifndef ROBOKASIV2_HOST_SERIALCONFIG_HPP
 #define ROBOKASIV2_HOST_SERIALCONFIG_HPP
 
-#include "hwio/SerialProto.hpp"
-
 #ifndef WITHOUT_LIBSERIALPORT
 #include <libserialport.h>
 #endif
+
+#include <functional>
 
 
 namespace gui {
 
     class SerialConfig {
     public:
-        SerialConfig(hwio::SerialProto& serialProto);
+        SerialConfig(std::string name,
+                     std::function<int(std::string port, int baud)> connectCb);
         ~SerialConfig();
         void render();
     private:
@@ -21,7 +22,8 @@ namespace gui {
 #endif
         int                 _port_idx;
         int                 _port_baud;
-        hwio::SerialProto&  _serialProto;
+        std::string         _name;
+        std::function<int(std::string port, int baud)> _connectCb;
     };
 
 }

--- a/src/app/SDLApp.cpp
+++ b/src/app/SDLApp.cpp
@@ -31,7 +31,9 @@ SDLApp::SDLApp(const SDLApp::Settings &settings) :
     _frameTicks (0),
     _serialProto        (),
     _commandQueue       (_serialProto),
-    _serialConfigGui    (_serialProto),
+    _serialConfigGui    ("Motor drive",
+                         std::bind(&hwio::SerialProto::connect, &_serialProto,
+                                   std::placeholders::_1, std::placeholders::_2)),
     _driveControlGui    (_serialProto, _commandQueue, _visualizerConfig),
     _programEditor      (_program, _visualizerConfig),
     _programAnimator    (_program, _visualizerConfig),
@@ -230,7 +232,8 @@ void SDLApp::render(void)
     ImGui::NewFrame();
 
     // Generate widgets
-    _serialConfigGui.render();
+    if (!_serialProto.isConnected())
+        _serialConfigGui.render();
     _driveControlGui.render();
     _visualizerConfig.render(_model);
     _programEditor.render();


### PR DESCRIPTION
This allows for reuse of SerialConfig for other serial devices.